### PR TITLE
Add "listen_port" in config.json to allow listen on specific port 在config.json中加入自定义端口选项

### DIFF
--- a/config/json.go
+++ b/config/json.go
@@ -15,6 +15,7 @@ type AppConfigs struct {
 
 type Settings struct {
 	CdnServer string `json:"cdn_server"`
+  	Port string `json:"listen_port"`
 }
 
 type LevelDbConfigs struct {
@@ -26,6 +27,7 @@ func DefaultConfigs() *AppConfigs {
 		AppName: "elichika",
 		Settings: Settings{
 			CdnServer: "http://192.168.1.123/static",
+      			Port: "80",
 		},
 	}
 }

--- a/main.go
+++ b/main.go
@@ -12,5 +12,5 @@ func main() {
 	r := gin.Default()
 	router.Router(r)
 
-	r.Run(":80") // listen and serve on 0.0.0.0:8080 (for windows "localhost:8080")
+	r.Run(":"+config.Conf.Settings.Port) // listen and serve on 0.0.0.0:80 as default, or on a custom port defined in config.json
 }


### PR DESCRIPTION
I'm trying to change the port that elichika listen on, as my default 80 port has been taken by nginx. Thus I create this PR.
哪有默认80端口还改不了的道理，今天说什么我也要把端口号改成52146